### PR TITLE
update community admin email process

### DIFF
--- a/netlify/functions/sendMessageToCommunity.ts
+++ b/netlify/functions/sendMessageToCommunity.ts
@@ -1,6 +1,11 @@
 import { Handler } from "@netlify/functions";
 import { createClient } from "@supabase/supabase-js";
-import axios from "axios";
+import {
+  addNotificationRecord,
+  buildCommunityAdminMessage,
+  loadCommunitySupportEmails,
+  sendEmail,
+} from "../utils";
 
 const supabase = createClient(
   process.env.SUPABASE_URL,
@@ -24,38 +29,38 @@ export const handler: Handler = async (event) => {
     };
   }
 
+  /**
+   * params.subject - string
+   * params.message - string
+   * params.communityId - string
+   * params.relatedUrl - string
+   */
   const params = JSON.parse(event.body);
 
-  const community = await loadCommunity(params.communityId);
-  const noSubscriptions =
-    !community.support_message_subscriptions ||
-    community.support_message_subscriptions?.length === 0;
-  let contacts = [];
-  if (!community.support_email && noSubscriptions) {
-    contacts = await loadCommunityAdmins(params.communityId);
-  }
-  if (community.support_email) {
-    contacts = [{ name: community.name, email: community.support_email }];
-  }
-  if (Array.isArray(community.support_message_subscriptions)) {
-    contacts = contacts.concat(community.support_message_subscriptions);
-  }
-
-  const messages = contacts.map((contact) =>
-    buildMessage({
-      name: contact.name,
-      email: contact.email,
-      message: params.message,
-      responseEmail: params.responseEmail,
-      communityName: community.name,
-    })
-  );
-
-  try {
-    await sendCommunityContactEmail({ messages });
-    console.info("succesfully sent messages");
-  } catch (error) {
-    console.error("unable to send messages", error);
+  const contacts = await loadCommunitySupportEmails(params.communityId);
+  for (const contact of contacts) {
+    if (contact.id) {
+      await addNotificationRecord({
+        user_id: contact.id,
+        email: contact.email,
+        related_url: params.relatedUrl,
+        type: "community_admin_message",
+        message: params.message,
+        custom_fields: {
+          subject: params.subject,
+          send_email: contact.email_preferences?.send_community_admin_messages,
+        },
+      });
+    } else {
+      const message = buildCommunityAdminMessage({
+        name: contact.name,
+        email: contact.email,
+        message: params.message,
+        subject: params.subject,
+        relatedUrl: params.relatedUrl,
+      });
+      await sendEmail(message);
+    }
   }
 
   return {
@@ -65,75 +70,3 @@ export const handler: Handler = async (event) => {
     }),
   };
 };
-
-async function loadCommunity(communityId: string) {
-  const { data, error } = await supabase
-    .from("communities")
-    .select("*")
-    .eq("id", communityId)
-    .single();
-
-  if (error) {
-    console.error({ error });
-  }
-  if (data) {
-    return data;
-  }
-}
-
-async function loadCommunityAdmins(communityId: string) {
-  const { data, error } = await supabase
-    .from("profiles")
-    .select("*, community_memberships!inner(community_id, role_id)")
-    .eq("community_memberships.community_id", communityId)
-    .eq("community_memberships.role_id", 1);
-
-  if (error) {
-    console.error({ error });
-  }
-  if (data) {
-    return data.map((profile) => ({
-      name: profile.username,
-      email: profile.email,
-    }));
-  }
-}
-
-function sendCommunityContactEmail({ messages }: { messages: unknown[] }) {
-  return axios.post(
-    "https://api.mailjet.com/v3.1/send",
-    {
-      Messages: messages,
-    },
-    {
-      auth: {
-        username: process.env.MJ_USER,
-        password: process.env.MJ_PW,
-      },
-      timeout: 7000,
-    }
-  );
-}
-
-function buildMessage({ name, email, message, responseEmail, communityName }) {
-  return {
-    From: {
-      Email: "notifications@playabl.io",
-      Name: "Playabl Notifications",
-    },
-    To: [
-      {
-        Email: email,
-        Name: name,
-      },
-    ],
-    TemplateID: 3904163,
-    TemplateLanguage: true,
-    Subject: `New Community Message on Playabl - ${communityName}`,
-    Variables: {
-      communityName,
-      message,
-      responseEmail: responseEmail || "Anonymous",
-    },
-  };
-}

--- a/netlify/utils.ts
+++ b/netlify/utils.ts
@@ -1,0 +1,131 @@
+import { createClient } from "@supabase/supabase-js";
+import axios from "axios";
+
+const supabase = createClient(
+  process.env.SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE
+);
+
+export function sendEmail(message) {
+  return sendEmails([message]);
+}
+
+export function sendEmails(messages) {
+  return axios.post(
+    "https://api.mailjet.com/v3.1/send",
+    {
+      Messages: messages,
+    },
+    {
+      auth: {
+        username: process.env.MJ_USER,
+        password: process.env.MJ_PW,
+      },
+      timeout: 7000,
+    }
+  );
+}
+
+export async function loadCommunitySupportEmails(
+  communityId: string
+): Promise<
+  {
+    name: string;
+    email: string;
+    id?: string;
+    email_preferences?: Record<string, boolean>;
+  }[]
+> {
+  const community = await loadCommunity(communityId);
+  const admins = await loadCommunityAdmins(communityId);
+  let contacts = [];
+  contacts = contacts.concat(admins);
+
+  if (community.support_email) {
+    contacts = contacts.concat({
+      name: community.name,
+      email: community.support_email,
+    });
+  }
+
+  return contacts;
+}
+
+async function loadCommunity(communityId: string) {
+  const { data, error } = await supabase
+    .from("communities")
+    .select("*")
+    .eq("id", communityId)
+    .single();
+
+  if (error) {
+    console.error({ error });
+  }
+  if (data) {
+    return data;
+  }
+}
+
+export async function loadCommunityAdmins(communityId: string) {
+  const { data, error } = await supabase
+    .from("profiles")
+    .select("*, community_memberships!inner(community_id, role_id)")
+    .eq("community_memberships.community_id", communityId)
+    .eq("community_memberships.role_id", 1);
+
+  if (error) {
+    console.error({ error });
+  }
+  if (data) {
+    return data.map((profile) => ({
+      name: profile.username,
+      email: profile.email,
+      id: profile.id,
+      email_preferences: profile.email_preferences,
+    }));
+  }
+}
+
+export async function addNotificationRecord(notification: {
+  user_id: string;
+  user_name?: string;
+  email: string;
+  message: string;
+  related_url: string;
+  type: "community_admin_message";
+  custom_fields: unknown;
+}) {
+  const { error } = await supabase.from("notifications").insert(notification);
+  if (error) {
+    throw error;
+  }
+}
+
+export function buildCommunityAdminMessage({
+  name,
+  email,
+  message,
+  subject,
+  relatedUrl,
+}) {
+  return {
+    From: {
+      Email: "notifications@playabl.io",
+      Name: "Playabl Notifications",
+    },
+    To: [
+      {
+        Email: email,
+        Name: name,
+      },
+    ],
+    TemplateID: 4954812,
+    TemplateLanguage: true,
+    Subject: subject,
+    Variables: {
+      message,
+      subject,
+      related_url: relatedUrl,
+    },
+  };
+}

--- a/src/api/messages.ts
+++ b/src/api/messages.ts
@@ -33,39 +33,6 @@ export async function loadMessagesToUser(userId: string) {
   }
 }
 
-export async function sendMessageToCommunity({
-  message,
-  responseEmail,
-  communityId,
-}: {
-  message: string;
-  communityId: string;
-  responseEmail?: string;
-}) {
-  const {
-    data: { session },
-  } = await supabase.auth.getSession();
-  if (!session?.access_token) return;
-  try {
-    const data = await axios({
-      url: `/.netlify/functions/sendMessageToCommunity`,
-      method: "POST",
-      headers: {
-        token: session.access_token,
-      },
-      data: {
-        message,
-        communityId,
-        responseEmail,
-      },
-    });
-    return data;
-  } catch (error) {
-    log({ error });
-    throw error;
-  }
-}
-
 export async function sendMessageAboutGame({
   message,
   responseEmail,

--- a/src/pages/Community/CommunityEmailSettings.vue
+++ b/src/pages/Community/CommunityEmailSettings.vue
@@ -2,33 +2,14 @@
   <form class="grid gap-2" @submit.prevent="handleSubmit">
     <Heading level="h6" as="h2"> Email Settings </Heading>
     <p class="text-sm text-slate-700 mb-4">
-      You can set a specific support email and any messages sent to the
-      community will be sent to this address. Additionally, you can choose to
-      subscribe individual Admins to support emails.
+      You can set a specific support email and recieve notifications there for
+      admin items such as membership requests. Community Admins automatically
+      are notified and can control email from their profile settings.
     </p>
     <div class="flex flex-col">
       <FormLabel for="description">Support email</FormLabel>
       <FormInput id="description" v-model="supportEmail" type="email" />
     </div>
-    <Well>
-      <p class="mb-2 font-semibold text-sm">
-        Subscribe Admins to support messages
-      </p>
-      <div
-        v-for="admin in communityStore.admins"
-        :key="admin.id"
-        class="flex items-center gap-2"
-      >
-        <FormCheckbox
-          :id="admin.id"
-          v-model="supportMessageSubscriptions"
-          :value="{ name: admin.username, email: admin.email }"
-        />
-        <FormLabel :for="admin.id" class="font-normal" no-margin>
-          {{ admin.username || admin.email }}
-        </FormLabel>
-      </div>
-    </Well>
     <PrimaryButton :is-loading="isSaving"> Update </PrimaryButton>
   </form>
 </template>
@@ -36,8 +17,6 @@
 import { ref } from "vue";
 import Heading from "@/components/Heading.vue";
 import PrimaryButton from "@/components/Buttons/PrimaryButton.vue";
-import Well from "@/components/Well.vue";
-import FormCheckbox from "@/components/Forms/FormCheckbox.vue";
 import FormLabel from "@/components/Forms/FormLabel.vue";
 import FormInput from "@/components/Forms/FormInput.vue";
 import { communityStore } from "./communityStore";
@@ -49,16 +28,12 @@ const { showError, showSuccess } = useToast();
 
 const isSaving = ref(false);
 const supportEmail = ref(communityStore.community.support_email ?? "");
-const supportMessageSubscriptions = ref(
-  communityStore.community.support_message_subscriptions ?? []
-);
 
 async function handleSubmit() {
   isSaving.value = true;
   try {
     const update: Partial<Community> = {
       support_email: supportEmail.value,
-      support_message_subscriptions: supportMessageSubscriptions.value,
     };
     await updateCommunity({
       communityId: communityStore.community.id,

--- a/src/pages/Community/CommunityHome.vue
+++ b/src/pages/Community/CommunityHome.vue
@@ -221,7 +221,6 @@ import useToast from "@/components/Toast/useToast";
 import { log } from "@/util/logger";
 import UserAvatar from "@/components/UserAvatar.vue";
 import RequestToJoinModal from "./RequestToJoinModal.vue";
-import { checkForCommunityRequest } from "@/api/communityMemberships";
 
 const { showSuccess, showError } = useToast();
 

--- a/src/pages/Community/RequestToJoinModal.vue
+++ b/src/pages/Community/RequestToJoinModal.vue
@@ -64,9 +64,10 @@ async function handleRequest() {
   submitting.value = true;
   try {
     const data = await submitCommunityMembershipRequest({
-      community_id: props.communityId,
-      user_id: store.user.id,
+      communityId: props.communityId,
+      userId: store.user.id,
       message: message.value,
+      communityName: props.communityName,
     });
     communityStore.membershipRequest = data;
     showSuccess({ message: "Membership requested submitted!" });

--- a/src/pages/Profile/GeneralNotification.vue
+++ b/src/pages/Profile/GeneralNotification.vue
@@ -1,0 +1,44 @@
+<template>
+  <li class="p-4">
+    <div class="flex flex-col">
+      <div class="flex justify-between">
+        <span class="flex items-center gap-2">
+          <InformationCircleIcon class="w-6 h-6 text-sky-600" />
+          <p class="font-semibold grow prose">
+            {{ notification.message }}
+          </p>
+        </span>
+        <div class="flex space-x-2 items-center mt-1">
+          <ClockIcon class="h-5 w-5 text-slate-700" />
+          <p class="text-slate-700">
+            {{ formatRelative(new Date(notification.created_at), new Date()) }}
+          </p>
+        </div>
+      </div>
+    </div>
+    <div class="flex justify-end gap-2 mt-3">
+      <LinkButton v-if="relative" :to="relative"> View </LinkButton>
+      <p>|</p>
+      <LinkButton @click="emit('clear')">Dismiss</LinkButton>
+    </div>
+  </li>
+</template>
+<script setup lang="ts">
+import { PropType, computed } from "vue";
+import { formatRelative } from "date-fns";
+import { InformationCircleIcon } from "@heroicons/vue/24/solid";
+import { ClockIcon } from "@heroicons/vue/24/outline";
+import { Notification } from "@/typings/Notification";
+import LinkButton from "@/components/Buttons/LinkButton.vue";
+const props = defineProps({
+  notification: {
+    type: Object as PropType<Notification>,
+    required: true,
+  },
+});
+const emit = defineEmits(["clear"]);
+const relative = computed(() => {
+  const url = new URL(props.notification.related_url ?? "");
+  return url?.pathname;
+});
+</script>

--- a/src/pages/Profile/NotificationsPage.vue
+++ b/src/pages/Profile/NotificationsPage.vue
@@ -40,6 +40,7 @@ import CancelNotification from "./CancelNotification.vue";
 import MembershipApprovalNotification from "./MembershipApprovalNotification.vue";
 import { clearNotification } from "@/api/notifications";
 import useToast from "@/components/Toast/useToast";
+import GeneralNotification from "./GeneralNotification.vue";
 
 const dismissingAll = ref(false);
 const { showError } = useToast();
@@ -54,7 +55,7 @@ function notificationComponent(type: Notification["type"]) {
     case "membership_request_approval":
       return MembershipApprovalNotification;
     default:
-      return "div";
+      return GeneralNotification;
   }
 }
 

--- a/src/pages/Profile/SettingsPage.vue
+++ b/src/pages/Profile/SettingsPage.vue
@@ -13,14 +13,20 @@
       <Heading level="h6" as="h3" class="mb-6">Email settings</Heading>
       <fieldset :disabled="emailsEnabled === false">
         <p class="mb-4">Email me when...</p>
-        <FormLabel class="flex items-center gap-2 font-normal mb-2" no-margin>
-          <FormCheckbox v-model="unreadNotificationEmailsEnabled" />
-          I have unread notifications from that day
-        </FormLabel>
-        <FormLabel class="flex items-center gap-2 font-normal" no-margin>
-          <FormCheckbox v-model="rsvpToMyGameEmailsEnabled" />
-          Someone joins my game
-        </FormLabel>
+        <div class="grid gap-2">
+          <FormLabel class="flex items-center gap-2 font-normal" no-margin>
+            <FormCheckbox v-model="unreadNotificationEmailsEnabled" />
+            I have unread notifications from that day
+          </FormLabel>
+          <FormLabel class="flex items-center gap-2 font-normal" no-margin>
+            <FormCheckbox v-model="rsvpToMyGameEmailsEnabled" />
+            Someone joins my game
+          </FormLabel>
+          <FormLabel class="flex items-center gap-2 font-normal" no-margin>
+            <FormCheckbox v-model="communityAdminEmailsEnabled" />
+            There are notifications for communities I manage
+          </FormLabel>
+        </div>
       </fieldset>
       <PrimaryButton
         :is-loading="saving"
@@ -56,6 +62,9 @@ const unreadNotificationEmailsEnabled = ref(
 const rsvpToMyGameEmailsEnabled = ref(
   store.user?.email_preferences?.rsvp_to_my_game_enabled ?? false
 );
+const communityAdminEmailsEnabled = ref(
+  store.user?.email_preferences?.send_community_admin_messages ?? false
+);
 const saving = ref(false);
 
 watch(
@@ -64,6 +73,7 @@ watch(
     if (newVal === false) {
       unreadNotificationEmailsEnabled.value = false;
       rsvpToMyGameEmailsEnabled.value = false;
+      communityAdminEmailsEnabled.value = false;
     }
   }
 );
@@ -75,6 +85,7 @@ async function updateEmailSettings() {
     email_enabled: emailsEnabled.value,
     unread_notifications_enabled: unreadNotificationEmailsEnabled.value,
     rsvp_to_my_game_enabled: rsvpToMyGameEmailsEnabled.value,
+    send_community_admin_messages: communityAdminEmailsEnabled.value,
   };
   try {
     await updateProfile({

--- a/src/typings/Profile.ts
+++ b/src/typings/Profile.ts
@@ -11,5 +11,6 @@ export interface Profile {
     email_enabled: boolean;
     unread_notifications_enabled: boolean;
     rsvp_to_my_game_enabled: boolean;
+    send_community_admin_messages: boolean;
   };
 }


### PR DESCRIPTION
Removes the community admin subscription leftover from messages. This sets up being able to notify community admins for events, and implements notifications for membership requests. It can serve as an example for future expansions.