### PR TITLE
Show session times in RSVP notifications

### DIFF
--- a/netlify/functions/processRsvp.ts
+++ b/netlify/functions/processRsvp.ts
@@ -53,6 +53,7 @@ export const handler: Handler = async (event) => {
           joiningUserName: user.username,
           gameId: game.id,
           gameName: game.title,
+          sessionStartTime: session.start_time,
         });
       } catch (error) {
         error.message =
@@ -249,6 +250,7 @@ async function notifyGameCreator({
   joiningUserName,
   gameId,
   gameName,
+  sessionStartTime,
 }) {
   const user = await getUserProfile({ userId: creatorId });
   const { data, error } = await supabase
@@ -263,6 +265,7 @@ async function notifyGameCreator({
       read: false,
       custom_fields: {
         send_notification_email: user.email_preferences.rsvp_to_my_game_enabled,
+        session_start_time: sessionStartTime,
       },
     })
     .select()

--- a/src/pages/Profile/RsvpNotification.vue
+++ b/src/pages/Profile/RsvpNotification.vue
@@ -14,6 +14,11 @@
             {{ formatRelative(new Date(notification.created_at), new Date()) }}
           </p>
         </div>
+        <div class="flex items-center gap-2" v-if="sessionStartTime">
+          <p class="text-slate-700">
+            {{ sessionStartTime }}
+          </p>
+        </div>
       </div>
     </div>
     <div class="flex justify-end gap-2 mt-3">
@@ -25,11 +30,12 @@
 </template>
 <script setup lang="ts">
 import { PropType, computed } from "vue";
-import { formatRelative } from "date-fns";
+import { formatRelative, format } from "date-fns";
 import { CheckCircleIcon } from "@heroicons/vue/24/solid";
 import { ClockIcon } from "@heroicons/vue/24/outline";
 import { Notification } from "@/typings/Notification";
 import LinkButton from "@/components/Buttons/LinkButton.vue";
+
 const props = defineProps({
   notification: {
     type: Object as PropType<Notification>,
@@ -40,5 +46,13 @@ const emit = defineEmits(["clear"]);
 const relative = computed(() => {
   const url = new URL(props.notification.related_url ?? "");
   return url?.pathname;
+});
+const sessionStartTime = computed(() => {
+  if (props.notification.custom_fields?.session_start_time) {
+    return format(
+      new Date(Number(props.notification.custom_fields?.session_start_time)),
+      "'Session starting' EEE, MMM do h:mm a O"
+    );
+  }
 });
 </script>


### PR DESCRIPTION
Resolves https://github.com/Playabl-io/playabl/issues/130

Shows the start time for the specific session that the user RSVP'd to:

![image](https://github.com/Playabl-io/playabl/assets/124014/b6dd8364-e477-4c6c-b476-603fae0dccf7)

NOTE: The layout could do with some love