### PR TITLE
move invite page behind auth shell

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,6 @@ jobs:
       - uses: supabase/setup-cli@v1
         with:
           version: latest
-      - run: supabase init
       - run: supabase db start
 
       # - name: Start Supabase local development setup

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,9 +29,11 @@ jobs:
       - uses: supabase/setup-cli@v1
         with:
           version: latest
+      - run: supabase init
+      - run: supabase db start
 
-      - name: Start Supabase local development setup
-        run: supabase start
+      # - name: Start Supabase local development setup
+      #   run: supabase start
 
       - name: Verify generated types are checked in
         run: |

--- a/src/pages/InvitePage.vue
+++ b/src/pages/InvitePage.vue
@@ -20,17 +20,12 @@
         <PrimaryButton
           class="w-full mt-4"
           :is-loading="joining"
-          :disabled="notSignedIn || joining"
+          :disabled="joining"
           @click="joinCommunity"
         >
           Join now
         </PrimaryButton>
       </div>
-      <SignUpModal
-        :open="notSignedIn"
-        :allow-dismiss="false"
-        @signed-in="notSignedIn = false"
-      />
     </div>
   </BaseTemplate>
 </template>
@@ -43,7 +38,6 @@ import { onMounted, ref } from "vue";
 import LoadingSpinner from "@/components/LoadingSpinner.vue";
 import PrimaryButton from "@/components/Buttons/PrimaryButton.vue";
 import useToast from "@/components/Toast/useToast";
-import SignUpModal from "@/components/Modals/SignUpModal.vue";
 
 const { showSuccess, showError } = useToast();
 
@@ -57,7 +51,6 @@ const inviteInfo = ref<{
 const isLoading = ref(false);
 const joining = ref(false);
 const alreadyJoined = ref(false);
-const notSignedIn = ref(false);
 
 async function loadCommunityInvite() {
   const { data } = await supabase
@@ -93,7 +86,7 @@ async function checkCommunityMember() {
 async function joinCommunity() {
   joining.value = true;
   const { data } = await fetch(
-    `/.netlify/functions/joinThroughInviteLink?inviteId=${route.params.invite_id}&userId=${store.user?.id}&communityId=${inviteInfo.value?.community_id.id}`,
+    `/.netlify/functions/joinThroughInviteLink?inviteId=${route.params.invite_id}&userId=${store.user?.id}&communityId=${inviteInfo.value?.community_id.id}`
   )
     .then((response) => response.json())
     .catch(() => {
@@ -110,9 +103,6 @@ async function joinCommunity() {
 
 onMounted(async () => {
   isLoading.value = true;
-  if (!store.user?.id) {
-    notSignedIn.value = true;
-  }
   await loadCommunityInvite();
   await checkCommunityMember();
   isLoading.value = false;

--- a/src/pages/InviteShell.vue
+++ b/src/pages/InviteShell.vue
@@ -1,0 +1,9 @@
+<template>
+  <AuthShell>
+    <InvitePage />
+  </AuthShell>
+</template>
+<script setup lang="ts">
+import AuthShell from "@/layouts/AuthShell.vue";
+import InvitePage from "./InvitePage.vue";
+</script>

--- a/src/router.ts
+++ b/src/router.ts
@@ -47,7 +47,7 @@ const routes = [
   },
   {
     path: "/invite/:invite_id",
-    component: () => import("@/pages/InvitePage.vue"),
+    component: () => import("@/pages/InviteShell.vue"),
     meta: {
       title: "Playabl",
     },


### PR DESCRIPTION
Received report that some invite links weren't working correctly. I don't know if this will fix it, but there have been race conditions with the auth in the past, and there's no reason to access the invite page until signed in anyways. Putting it behind the auth shell may help.