### PR TITLE
Do not include timezone in Google Calendar link

### DIFF
--- a/src/components/Game/AddToGoogleCal.vue
+++ b/src/components/Game/AddToGoogleCal.vue
@@ -34,12 +34,12 @@ const props = defineProps({
 
 const formattedStartTime = computed(() => {
   const dateString = format(props.startTime, "yyyyMMdd");
-  const timeString = format(props.startTime, "HHmmssX");
+  const timeString = format(props.startTime, "HHmmss");
   return `${dateString}T${timeString}`;
 });
 const formattedEndTime = computed(() => {
   const dateString = format(props.endTime, "yyyyMMdd");
-  const timeString = format(props.endTime, "HHmmssX");
+  const timeString = format(props.endTime, "HHmmss");
   return `${dateString}T${timeString}`;
 });
 


### PR DESCRIPTION
Fixes #284 

The date should already be rendered the local user's timezone, which is [what I believe Google is expecting](https://github.com/InteractionDesignFoundation/add-event-to-calendar-docs/blob/main/services/google.md#dates).

Alternatively, the dates should be rendered in UTC with a `Z` suffix. For example:

Does not work: 
- [Original](http://www.google.com/calendar/render?action=TEMPLATE&dates=20250706T080000+08/20250706T110000+08&details=Game%20details:%20https://app.playabl.io/games/1316&location=https://app.playabl.io/games/1316&text=Hearts%20of%20Sunnydale)

Does work:
- [Assume local time](http://www.google.com/calendar/render?action=TEMPLATE&dates=20250706T080000/20250706T110000&details=Game%20details:%20https://app.playabl.io/games/1316&location=https://app.playabl.io/games/1316&text=Hearts%20of%20Sunnydale) _should work in your local timezone_
- [Force to UTC](http://www.google.com/calendar/render?action=TEMPLATE&dates=20250706T000000Z/20250706T030000Z&details=Game%20details:%20https://app.playabl.io/games/1316&location=https://app.playabl.io/games/1316&text=Hearts%20of%20Sunnydale) _should be the same time for everyone_